### PR TITLE
Update atlas for 1.21 Armor Trims

### DIFF
--- a/src/main/resources/assets/minecraft/atlases/armor_trims.json
+++ b/src/main/resources/assets/minecraft/atlases/armor_trims.json
@@ -34,7 +34,11 @@
         "trims/models/armor/raiser",
         "trims/models/armor/raiser_leggings",
         "trims/models/armor/host",
-        "trims/models/armor/host_leggings"
+        "trims/models/armor/host_leggings",
+        "trims/models/armor/bolt",
+        "trims/models/armor/bolt_leggings",
+        "trims/models/armor/flow",
+        "trims/models/armor/flow_leggings"
       ],
       "palette_key": "trims/color_palettes/trim_palette",
       "permutations": {


### PR DESCRIPTION
Flow and Bolt Trims currently have broken armor models when a Stratus Ingot or a Skyjade Gemstone is used as the trim materials.

Before:
![BugFix](https://github.com/user-attachments/assets/ebf99c11-6883-44a6-a352-f591eed6f062)

After:
![BugFixed](https://github.com/user-attachments/assets/4a10a6cc-e641-47fb-978b-27edc0bf10cc)