### PR TITLE
Fix poison on lava interaction 1.20.1

### DIFF
--- a/src/generated/resources/data/minecraft/tags/blocks/leaves.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/leaves.json
@@ -7,7 +7,6 @@
     "deep_aether:yagroot_leaves",
     "deep_aether:cruderoot_leaves",
     "deep_aether:conberry_leaves",
-    "deep_aether:sunroot_leaves",
-    "deep_aether:yagroot_roots"
+    "deep_aether:sunroot_leaves"
   ]
 }

--- a/src/main/java/teamrazor/deepaether/datagen/tags/DABlockTagData.java
+++ b/src/main/java/teamrazor/deepaether/datagen/tags/DABlockTagData.java
@@ -273,8 +273,7 @@ public class DABlockTagData extends BlockTagsProvider {
                 DABlocks.YAGROOT_LEAVES.get(),
                 DABlocks.CRUDEROOT_LEAVES.get(),
                 DABlocks.CONBERRY_LEAVES.get(),
-                DABlocks.SUNROOT_LEAVES.get(),
-                DABlocks.YAGROOT_ROOTS.get()
+                DABlocks.SUNROOT_LEAVES.get()
         );
 
         tag(BlockTags.NEEDS_STONE_TOOL).add(

--- a/src/main/java/teamrazor/deepaether/mixin/LavaFluidMixin.java
+++ b/src/main/java/teamrazor/deepaether/mixin/LavaFluidMixin.java
@@ -1,0 +1,24 @@
+package teamrazor.deepaether.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.material.FlowingFluid;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.LavaFluid;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import teamrazor.deepaether.datagen.tags.DATags;
+
+/*
+    This mixin is used to override the behaviour of fluid interactions with lava.
+    This is because with the existing fluid interaction system, lava's interactions
+    are not taken into account and are hardcoded.
+ */
+@Mixin(LavaFluid.class)
+public abstract class LavaFluidMixin extends FlowingFluid {
+    @ModifyReturnValue(method = "canBeReplacedWith", at = @At("RETURN"))
+    private boolean deep_Aether$lavaReplaceOverride(boolean original, @Local(argsOnly = true) Fluid fluid, @Local(argsOnly = true) Direction direction){
+        return original || (direction == Direction.DOWN && fluid.is(DATags.Fluids.POISON));
+    }
+}

--- a/src/main/resources/deep_aether.mixins.json
+++ b/src/main/resources/deep_aether.mixins.json
@@ -14,7 +14,8 @@
     "MoaMixin",
     "PowderSnowBlockMixin",
     "ServerPlayerMixin",
-    "TriviaGeneratorMixin"
+    "TriviaGeneratorMixin",
+    "LavaFluidMixin"
   ],
   "client": [
     "AerwhaleModelMixin",


### PR DESCRIPTION
There's a 7-8 or so stretch of commits that didn't directly make their way from the 1.20.1-1.0 branch to the 1.20.1-1.1 branch

<details>
  <summary> right side output of `git log --oneline --left-right 1.20.1-1.1...1.20.1-1.0` </summary>
  
```
> 07a815e4 (origin/1.20.1-1.0, 1.20.1-1.0) fix: Closes #162
> 3fec93d1 Feature: Crowdin Setup
> f823c832 Revert "Feature: NEW TEXTURES"
> aa75c0a3 Feature: NEW TEXTURES
> 8d7d4e49 Update README.md
> f8ea8761 Fix
> c4b8f593 Fix
> bb049197 Huge Lightcap Mushroom closes #170
> b035aa6a Removed some unused classes
> fa21b561 Finalize Protect Your Moa compat x2
> ca207db1 Finalize Protect Your Moa compat
> beeb3147 Fix closes #184
> 52296276 Enhance: Some Addon Compatibility (Textures Missing)
```
  
</details>

including this one fixing the poison on lava behaviour. As far as I can quickly tell the other features or fixes did make it in just via different commits, but never this one. 

Also backports the fix for #161