### PR TITLE
Add Skyjade Gemstones to #C:Gems tag - Aria

### DIFF
--- a/src/generated/resources/data/c/tags/item/gems.json
+++ b/src/generated/resources/data/c/tags/item/gems.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "deep_aether:skyjade"
+  ]
+}

--- a/src/main/java/io/github/razordevs/deep_aether/datagen/tags/DAItemTagData.java
+++ b/src/main/java/io/github/razordevs/deep_aether/datagen/tags/DAItemTagData.java
@@ -584,6 +584,11 @@ public class DAItemTagData extends ItemTagsProvider {
         tag(Tags.Items.INGOTS).add(
                 DAItems.STRATUS_INGOT.get()
         );
+
+        tag(Tags.Items.GEMS).add(
+                DAItems.SKYJADE.get()
+        );
+
         tag(DATags.Items.FLAWLESS_ITEMS).add(
                 DAItems.SLIDER_EYE.get(),
                 DAItems.MEDAL_OF_HONOR.get(),


### PR DESCRIPTION
This just mirrors that Zanite Gemstones are under the #Gems tag.