### PR TITLE
Fixes Skyjade Ore (#303)

### DIFF
--- a/src/generated/resources/data/aether/tags/block/ores_in_ground/holystone.json
+++ b/src/generated/resources/data/aether/tags/block/ores_in_ground/holystone.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "deep_aether:skyjade_ore"
+  ]
+}

--- a/src/generated/resources/data/aether/tags/item/ores_in_ground/holystone.json
+++ b/src/generated/resources/data/aether/tags/item/ores_in_ground/holystone.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "deep_aether:skyjade_ore"
+  ]
+}

--- a/src/generated/resources/data/c/tags/block/ore_rates/singular.json
+++ b/src/generated/resources/data/c/tags/block/ore_rates/singular.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "deep_aether:skyjade_ore"
+  ]
+}

--- a/src/generated/resources/data/c/tags/block/ores.json
+++ b/src/generated/resources/data/c/tags/block/ores.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "deep_aether:skyjade_ore"
+  ]
+}

--- a/src/generated/resources/data/c/tags/item/ore_rates/singular.json
+++ b/src/generated/resources/data/c/tags/item/ore_rates/singular.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "deep_aether:skyjade_ore"
+  ]
+}

--- a/src/generated/resources/data/c/tags/item/ores.json
+++ b/src/generated/resources/data/c/tags/item/ores.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "deep_aether:skyjade_ore"
+  ]
+}

--- a/src/main/java/io/github/razordevs/deep_aether/datagen/tags/DABlockTagData.java
+++ b/src/main/java/io/github/razordevs/deep_aether/datagen/tags/DABlockTagData.java
@@ -675,6 +675,16 @@ public class DABlockTagData extends BlockTagsProvider {
                 DABlocks.TALL_GLOWING_GRASS.get()
         );
 
+        tag(AetherTags.Blocks.ORES_IN_GROUND_HOLYSTONE).add(
+                DABlocks.SKYJADE_ORE.get()
+        );
+        tag(Tags.Blocks.ORES).add(
+                DABlocks.SKYJADE_ORE.get()
+        );
+        tag(Tags.Blocks.ORE_RATES_SINGULAR).add(
+                DABlocks.SKYJADE_ORE.get()
+        );
+
         tag(AetherTags.Blocks.DUNGEON_BLOCKS).add(
                 DABlocks.NIMBUS_STONE.get(),
                 DABlocks.LIGHT_NIMBUS_STONE.get(),

--- a/src/main/java/io/github/razordevs/deep_aether/datagen/tags/DAItemTagData.java
+++ b/src/main/java/io/github/razordevs/deep_aether/datagen/tags/DAItemTagData.java
@@ -557,6 +557,15 @@ public class DAItemTagData extends ItemTagsProvider {
         tag(DATags.Items.STORM_REPAIRING).add(
                 DAItems.SQUALL_PLATE.get()
         );
+        tag(AetherTags.Items.ORES_IN_GROUND_HOLYSTONE).add(
+                DABlocks.SKYJADE_ORE.get().asItem()
+        );
+        tag(Tags.Items.ORES).add(
+                DABlocks.SKYJADE_ORE.get().asItem()
+        );
+        tag(Tags.Items.ORE_RATES_SINGULAR).add(
+                DABlocks.SKYJADE_ORE.get().asItem()
+        );
 
         // Boats & Chests
         tag(ItemTags.BOATS).add(


### PR DESCRIPTION
Adds `c:ores`, `c:ore_rates/singular`, and `aether:ores_in_ground/holystone` tags to Skyjade Ore. 

Mimics Zanite's tags :>