### PR TITLE
Fix crash with Tinkerer's Smithing [1.20.1]

### DIFF
--- a/src/main/java/teamrazor/deepaether/item/gear/DaArmorMaterials.java
+++ b/src/main/java/teamrazor/deepaether/item/gear/DaArmorMaterials.java
@@ -8,8 +8,6 @@ import net.minecraft.world.item.ArmorMaterial;
 import net.minecraft.world.item.ArmorMaterials;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import teamrazor.deepaether.datagen.tags.DATags;
 import teamrazor.deepaether.init.DASounds;
 
@@ -94,7 +92,6 @@ public enum DaArmorMaterials implements StringRepresentable, ArmorMaterial {
     }
 
     @Override
-    @OnlyIn(Dist.CLIENT)
     public String getName() {
         return this.name;
     }


### PR DESCRIPTION
This pull request removes an unnecessary `@OnlyIn` annotation from DaArmorMaterials::getName.

This annotation causes a problem with mods like [Tinkerer's Smithing](https://modrinth.com/mod/tinkerers-smithing) that call getName from the server side, which is supposed to work since ArmorMaterial::getName is not marked as `@OnlyIn` in 1.20.1. So if you try to install Tinkerer's Smithing you get the following crash:
```
java.lang.AbstractMethodError: Receiver class teamrazor.deepaether.item.gear.DaArmorMaterials does not define or inherit an implementation of the resolved method 'abstract java.lang.String m_6082_()' of interface net.minecraft.world.item.ArmorMaterial.
```

This bug is technically also present on 1.20.4, 1.19.4 and 1.19.2 as well, but 1.20.1 is the only affected version where I think people might try to combine this with Tinkerer's Smithing.