### PR TITLE
Mark Lost Aether Content as an explicit optional dependency.

### DIFF
--- a/src/main/templates/META-INF/mods.toml
+++ b/src/main/templates/META-INF/mods.toml
@@ -42,3 +42,10 @@ versionRange="[1.0.1,)"
 ordering="NONE"
 side="BOTH"
 
+[[dependencies.${mod_id}]]
+modId="lost_aether_content"
+versionRange="[1.1.0,)"
+mandatory=false
+ordering="AFTER"
+side="BOTH"
+


### PR DESCRIPTION
Deep Aether needs to load after Lost Aether Content to prevent the following crash:
```
java.lang.IllegalArgumentException: Failed to create model for aether:aerwhale
Caused by: java.util.NoSuchElementException: Can't find part left_chest
```

It's just that there isn't really anything making sure Deep Aether always loads after Lost Aether Content at the moment. The mod id for Lost Aether Content just happens to end up before Deep Aether's mod id in a hash map used to check for mod duplicates during the startup process.

As you can probably imagine, that's quite brittle. So I thought it would be a good idea to add it as an explicit optional dependency to mods.toml. That way Forge will make sure Lost Aether Content is always the first to load, avoiding the crash.

As far as I can tell this only affects 1.20.1 for now.