### PR TITLE
fix: guard onPlayerUpdate against non-Player entities

### DIFF
--- a/src/main/java/io/github/razordevs/deep_aether/event/DAGeneralEvents.java
+++ b/src/main/java/io/github/razordevs/deep_aether/event/DAGeneralEvents.java
@@ -257,8 +257,8 @@ public class DAGeneralEvents {
 
     @SubscribeEvent
     public static void onPlayerUpdate(EntityTickEvent.Post event) {
-        if (event.getEntity().hasData(DAAttachments.PLAYER))
-            event.getEntity().getData(DAAttachments.PLAYER).onUpdate(((Player) event.getEntity()));
+        if (event.getEntity() instanceof Player player && player.hasData(DAAttachments.PLAYER))
+            player.getData(DAAttachments.PLAYER).onUpdate(player);
     }
 
     @SubscribeEvent


### PR DESCRIPTION
`DAGeneralEvents.onPlayerUpdate` is subscribed to `EntityTickEvent.Post`, which fires for every ticking entity, but it casts the entity to `Player` after only an attachment check. Any non-player entity carrying `DAAttachments.PLAYER` reaches the cast and throws `ClassCastException`, crashing the server.
 
On a 1.21.1 / NeoForge 21.1.231 dedicated server this showed up as a crash loop. The real exception was masked by `ServerHangWatchdog` reports (`a single server tick took 60000004.00 seconds`), the actual cause was only in `latest.log`:
 
```
ClassCastException: Villager cannot be cast to Player
  at DAGeneralEvents.onPlayerUpdate(DAGeneralEvents.java:261)
  via fireEntityTickPost -> Ticking entity -> server shutdown
```
